### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postgresql",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": "Inkling/Puppet Labs",
   "summary": "PostgreSQL defined resource types",
   "license": "ASL 2.0",
@@ -69,7 +69,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "4.x"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/apt",
@@ -77,7 +77,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-postgresql`
SIMP-1628 #close
