### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,11 @@
+---
 fixtures:
   repositories:
-    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
-    concat: "https://github.com/simp/pupmod-simp-concat.git"
+    apt: https://github.com/puppetlabs/puppetlabs-apt.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    firewall: https://github.com/puppetlabs/puppetlabs-firewall.git
+    concat:
+      repo: https://github.com/simp/pupmod-simp-concat.git
+      branch: 5.X
   symlinks:
     postgresql: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in postgresql
